### PR TITLE
use Symfony request to check whether the request is secure or not

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.0.2
+* Set `secure` attribute for `device_view` cookie in `DeviceViewListener` based on the `request` itself.
+
+
 ## v1.0.1
 * Use `SameSite=strict` for device_view cookie in `DeviceViewListener`.
 

--- a/src/EventListener/DeviceViewListener.php
+++ b/src/EventListener/DeviceViewListener.php
@@ -66,7 +66,7 @@ final class DeviceViewListener implements EventSubscriberInterface
                 0,
                 '/',
                 null,
-                isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? true : false,
+                $request->isSecure(),
                 true,
                 false,
                 Cookie::SAMESITE_STRICT

--- a/src/EventListener/DeviceViewListener.php
+++ b/src/EventListener/DeviceViewListener.php
@@ -66,7 +66,7 @@ final class DeviceViewListener implements EventSubscriberInterface
                 0,
                 '/',
                 null,
-                true,
+                isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? true : false,
                 true,
                 false,
                 Cookie::SAMESITE_STRICT


### PR DESCRIPTION
Set `secure` attribute for `device_view` cookie in `DeviceViewListener` based on the `request` itself.